### PR TITLE
Update stirling-pdf to 0.33.1 and some enhancements

### DIFF
--- a/charts/stirling-pdf/Chart.yaml
+++ b/charts/stirling-pdf/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-appVersion: 0.32.0
+appVersion: 0.33.1
 description:
   locally hosted web application that allows you to perform various operations on PDF files
 home: https://github.com/Stirling-Tools/Stirling-PDF
@@ -13,4 +13,4 @@ maintainers:
 name: stirling-pdf-chart
 sources:
   - https://github.com/Stirling-Tools/Stirling-PDF-chart
-version: 1.1.0
+version: 1.2.0

--- a/charts/stirling-pdf/README.md
+++ b/charts/stirling-pdf/README.md
@@ -41,7 +41,8 @@ helm repo add stirling-pdf https://stirling-tools.github.io/Stirling-PDF-chart
 | extraArgs | list | `[]` |  |
 | image.pullPolicy | string | `"IfNotPresent"` |  |
 | image.repository | string | `"frooodle/s-pdf"` |  |
-| image.tag | string | `nil` |  |
+| image.sha | string | `""` |  |
+| image.tag | string | `""` | Overrides the image tag whose default is the chart appVersion. |
 | ingress | object | `{"annotations":{},"enabled":false,"hosts":[],"ingressClassName":null,"labels":{},"pathType":"ImplementationSpecific"}` | Ingress for load balancer |
 | ingress.annotations | object | `{}` | Stirling-pdf Ingress annotations |
 | ingress.hosts | list | `[]` | Must be provided if Ingress is enabled |

--- a/charts/stirling-pdf/README.md
+++ b/charts/stirling-pdf/README.md
@@ -40,6 +40,7 @@ helm repo add stirling-pdf https://stirling-tools.github.io/Stirling-PDF-chart
 | envsFrom | list | `[]` | Environment variables from secrets or configmaps to add to the stirling-pdf pods |
 | extraArgs | list | `[]` |  |
 | image.pullPolicy | string | `"IfNotPresent"` |  |
+| image.registry | string | `"ghcr.io"` |  |
 | image.repository | string | `"frooodle/s-pdf"` |  |
 | image.sha | string | `""` |  |
 | image.tag | string | `""` | Overrides the image tag whose default is the chart appVersion. |

--- a/charts/stirling-pdf/README.md
+++ b/charts/stirling-pdf/README.md
@@ -1,6 +1,6 @@
 # stirling-pdf-chart
 
-![Version: 1.1.0](https://img.shields.io/badge/Version-1.1.0-informational?style=flat-square) ![AppVersion: 0.32.0](https://img.shields.io/badge/AppVersion-0.32.0-informational?style=flat-square)
+![Version: 1.2.0](https://img.shields.io/badge/Version-1.2.0-informational?style=flat-square) ![AppVersion: 0.33.1](https://img.shields.io/badge/AppVersion-0.33.1-informational?style=flat-square)
 
 locally hosted web application that allows you to perform various operations on PDF files
 
@@ -41,7 +41,7 @@ helm repo add stirling-pdf https://stirling-tools.github.io/Stirling-PDF-chart
 | extraArgs | list | `[]` |  |
 | image.pullPolicy | string | `"IfNotPresent"` |  |
 | image.registry | string | `"ghcr.io"` |  |
-| image.repository | string | `"frooodle/s-pdf"` |  |
+| image.repository | string | `"stirling-tools/stirling-pdf"` |  |
 | image.sha | string | `""` |  |
 | image.tag | string | `""` | Overrides the image tag whose default is the chart appVersion. |
 | ingress | object | `{"annotations":{},"enabled":false,"hosts":[],"ingressClassName":null,"labels":{},"pathType":"ImplementationSpecific"}` | Ingress for load balancer |

--- a/charts/stirling-pdf/templates/deployment.yaml
+++ b/charts/stirling-pdf/templates/deployment.yaml
@@ -58,7 +58,11 @@ spec:
 {{- include "stirlingpdf.imagePullSecrets" . | indent 6 }}
       containers:
       - name: {{ .Chart.Name }}
-        image: {{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}
+        {{- if .Values.image.sha }}
+        image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}@sha256:{{ .Values.image.sha }}"
+        {{- else }}
+        image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+        {{- end }}
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         securityContext:
           {{- toYaml .Values.containerSecurityContext | nindent 10 }}

--- a/charts/stirling-pdf/templates/deployment.yaml
+++ b/charts/stirling-pdf/templates/deployment.yaml
@@ -59,9 +59,9 @@ spec:
       containers:
       - name: {{ .Chart.Name }}
         {{- if .Values.image.sha }}
-        image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}@sha256:{{ .Values.image.sha }}"
+        image: "{{ .Values.image.registry }}/{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}@sha256:{{ .Values.image.sha }}"
         {{- else }}
-        image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+        image: "{{ .Values.image.registry }}/{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
         {{- end }}
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         securityContext:

--- a/charts/stirling-pdf/values.yaml
+++ b/charts/stirling-pdf/values.yaml
@@ -5,6 +5,7 @@ replicaCount: 1
 strategy:
   type: RollingUpdate
 image:
+  registry: ghcr.io
   repository: frooodle/s-pdf
   # -- Overrides the image tag whose default is the chart appVersion.
   tag: ""

--- a/charts/stirling-pdf/values.yaml
+++ b/charts/stirling-pdf/values.yaml
@@ -6,8 +6,9 @@ strategy:
   type: RollingUpdate
 image:
   repository: frooodle/s-pdf
-  # took Chart appVersion by default
-  tag: ~
+  # -- Overrides the image tag whose default is the chart appVersion.
+  tag: ""
+  sha: ""
   pullPolicy: IfNotPresent
 secret:
   labels: {}

--- a/charts/stirling-pdf/values.yaml
+++ b/charts/stirling-pdf/values.yaml
@@ -6,7 +6,7 @@ strategy:
   type: RollingUpdate
 image:
   registry: ghcr.io
-  repository: frooodle/s-pdf
+  repository: stirling-tools/stirling-pdf
   # -- Overrides the image tag whose default is the chart appVersion.
   tag: ""
   sha: ""


### PR DESCRIPTION
- Support pinning image sha
- Use by default ghcr.io to prevent docker hub rate limit
- Update image repository name
- Upgrade stirling-pdf to 0.33.1

@Frooodle you can use rebase merging to keep commits history :)