### PR TITLE
Feat: add support for custom initContainers

### DIFF
--- a/charts/stirling-pdf/templates/deployment.yaml
+++ b/charts/stirling-pdf/templates/deployment.yaml
@@ -48,7 +48,7 @@ spec:
       {{- if .Values.deployment.initContainers }}
       initContainers:
         {{- toYaml .Values.deployment.initContainers | nindent 8 }}
-      {{- else if and (not .Values.securityContext.enabled) .Values.persistence.enabled }}
+      {{- else if .Values.persistence.enabled }}
       initContainers:
       - name: volume-permissions
         image: {{ template "stirlingpdf.volumePermissions.image" . }}

--- a/charts/stirling-pdf/values.yaml
+++ b/charts/stirling-pdf/values.yaml
@@ -54,11 +54,11 @@ deployment:
   # -- Additional volumes to mount
   extraVolumeMounts: []
   # -- Custom initContainers specification
-  # -- If specified, these initContainers will be used instead of the default
-  # -- volume-permissions initContainer. This allows full control over the
-  # -- initContainer configuration.
-  # -- NOTE: When this is set, it completely overrides the default initContainer
-  # -- behavior. Make sure to include any necessary volume permission setup if needed.
+  # If specified, these initContainers will be used instead of the default
+  # volume-permissions initContainer. This allows full control over the
+  # initContainer configuration.
+  # NOTE: When this is set, it completely overrides the default initContainer
+  # behavior. Make sure to include any necessary volume permission setup if needed.
   initContainers: []
   #  - name: custom-init
   #    image: busybox:latest


### PR DESCRIPTION
Add the ability to specify custom initContainers via deployment.initContainers
in values.yaml. When specified, custom initContainers override the default
volume-permissions initContainer, providing full flexibility for initialization
logic while maintaining backward compatibility.

### Community Note

- Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
- Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request
