### PR TITLE
feat(chart): optional HorizontalPodAutoscaler and PodDisruptionBudget

### DIFF
--- a/charts/stirling-pdf/templates/hpa.yaml
+++ b/charts/stirling-pdf/templates/hpa.yaml
@@ -1,0 +1,31 @@
+{{- if .Values.autoscaling.enabled }}
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "stirlingpdf.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "stirlingpdf.labels" . | nindent 4 }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "stirlingpdf.fullname" . }}
+  minReplicas: {{ .Values.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.autoscaling.maxReplicas }}
+  metrics:
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.autoscaling.targetCPUUtilizationPercentage }}
+    {{- if gt (int (.Values.autoscaling.targetMemoryUtilizationPercentage | default 0)) 0 }}
+    - type: Resource
+      resource:
+        name: memory
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.autoscaling.targetMemoryUtilizationPercentage }}
+    {{- end }}
+{{- end }}

--- a/charts/stirling-pdf/templates/pdb.yaml
+++ b/charts/stirling-pdf/templates/pdb.yaml
@@ -1,0 +1,18 @@
+{{- if .Values.podDisruptionBudget.enabled }}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "stirlingpdf.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "stirlingpdf.labels" . | nindent 4 }}
+spec:
+  {{- if .Values.podDisruptionBudget.maxUnavailable }}
+  maxUnavailable: {{ .Values.podDisruptionBudget.maxUnavailable }}
+  {{- else }}
+  minAvailable: {{ .Values.podDisruptionBudget.minAvailable }}
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "stirlingpdf.selectorLabels" . | nindent 6 }}
+{{- end }}

--- a/charts/stirling-pdf/values.yaml
+++ b/charts/stirling-pdf/values.yaml
@@ -263,3 +263,18 @@ ingress:
   # -- For Kubernetes >= 1.18 you should specify the ingress-controller via the field ingressClassName
   # -- See https://kubernetes.io/blog/2020/04/02/improvements-to-the-ingress-api-in-kubernetes-1.18/#specifying-the-class-of-an-ingress
   ingressClassName:
+
+# -- Horizontal Pod Autoscaler (autoscaling/v2). Requires resource requests on the Deployment.
+autoscaling:
+  enabled: false
+  minReplicas: 1
+  maxReplicas: 10
+  targetCPUUtilizationPercentage: 80
+  # -- When > 0, adds a memory utilization metric to the HPA
+  targetMemoryUtilizationPercentage: 0
+
+# -- Pod Disruption Budget for the Deployment. Use either minAvailable or maxUnavailable (not both).
+podDisruptionBudget:
+  enabled: false
+  minAvailable: 1
+  # maxUnavailable: 1


### PR DESCRIPTION
## Summary
- Add optional **HorizontalPodAutoscaler** (`autoscaling/v2`) targeting the main Deployment, driven by `values.autoscaling` (disabled by default).
- Add optional **PodDisruptionBudget** (`policy/v1`) with the same selector labels as the Deployment, driven by `values.podDisruptionBudget` (disabled by default).
- Document new keys in `values.yaml`.

## Motivation
Downstream deployments often need HPA and PDB next to the chart. Shipping them as opt-in templates avoids maintaining parallel manifests and keeps labels/selectors consistent with `stirlingpdf.selectorLabels`.

## Notes
- HPA uses CPU utilization by default; memory is added only when `targetMemoryUtilizationPercentage` is set to a value **> 0**.
- PDB: set `maxUnavailable` **or** rely on `minAvailable` (default `1` when `maxUnavailable` is unset).
- Tested locally with: `helm template test . --set autoscaling.enabled=true --set podDisruptionBudget.enabled=true`.