### PR TITLE
feat: add HTTPRoute (Gateway API) support

### DIFF
--- a/charts/stirling-pdf/Chart.yaml
+++ b/charts/stirling-pdf/Chart.yaml
@@ -12,4 +12,4 @@ maintainers:
 name: stirling-pdf-chart
 sources:
   - https://github.com/Stirling-Tools/Stirling-PDF-chart
-version: 3.1.0
+version: 3.2.0

--- a/charts/stirling-pdf/README.md
+++ b/charts/stirling-pdf/README.md
@@ -41,6 +41,12 @@ helm repo add stirling-pdf https://docs.stirlingpdf.com/Stirling-PDF-chart
 | envs | list | `[]` | Environment variables to add to the stirling-pdf pods |
 | envsFrom | list | `[]` | Environment variables from secrets or configmaps to add to the stirling-pdf pods |
 | extraArgs | list | `[]` |  |
+| httpRoute | object | `{"annotations":{},"enabled":false,"hostnames":[],"labels":{},"parentRefs":[],"rules":[]}` | HTTPRoute (Gateway API) for load balancing. When enabled, an HTTPRoute resource is rendered alongside (or instead of) the Ingress. |
+| httpRoute.annotations | object | `{}` | Stirling-pdf HTTPRoute annotations |
+| httpRoute.hostnames | list | `[]` | HTTPRoute hostnames. Must match the host the client requests. |
+| httpRoute.labels | object | `{}` | Stirling-pdf HTTPRoute labels |
+| httpRoute.parentRefs | list | `[]` | HTTPRoute parentRefs (the Gateway(s) this route attaches to). Must be provided if HTTPRoute is enabled. See https://gateway-api.sigs.k8s.io/api-types/httproute/#attaching-to-gateways |
+| httpRoute.rules | list | `[]` | HTTPRoute rules. If empty, a default rule is rendered that routes all traffic to the chart's own Service on service.externalPort. |
 | image.pullPolicy | string | `"IfNotPresent"` |  |
 | image.registry | string | `"docker.stirlingpdf.com"` |  |
 | image.repository | string | `"stirlingtools/stirling-pdf"` |  |

--- a/charts/stirling-pdf/README.md
+++ b/charts/stirling-pdf/README.md
@@ -1,6 +1,6 @@
 # stirling-pdf-chart
 
-![Version: 3.1.0](https://img.shields.io/badge/Version-3.1.0-informational?style=flat-square) ![AppVersion: 2.5.1](https://img.shields.io/badge/AppVersion-2.5.1-informational?style=flat-square)
+![Version: 3.2.0](https://img.shields.io/badge/Version-3.2.0-informational?style=flat-square) ![AppVersion: 2.5.1](https://img.shields.io/badge/AppVersion-2.5.1-informational?style=flat-square)
 
 locally hosted web application that allows you to perform various operations on PDF files
 

--- a/charts/stirling-pdf/templates/httproute.yaml
+++ b/charts/stirling-pdf/templates/httproute.yaml
@@ -1,0 +1,37 @@
+{{- if .Values.httpRoute.enabled }}
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: {{ include "stirlingpdf.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "stirlingpdf.labels" . | nindent 4 }}
+    {{- with .Values.httpRoute.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- with .Values.httpRoute.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- with .Values.httpRoute.parentRefs }}
+  parentRefs:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with .Values.httpRoute.hostnames }}
+  hostnames:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  rules:
+    {{- if .Values.httpRoute.rules }}
+    {{- toYaml .Values.httpRoute.rules | nindent 4 }}
+    {{- else }}
+    - matches:
+        - path:
+            type: PathPrefix
+            value: {{ .Values.rootPath | default "/" }}
+      backendRefs:
+        - name: {{ .Values.service.servicename | default (include "stirlingpdf.fullname" .) }}
+          port: {{ .Values.service.externalPort }}
+    {{- end }}
+{{- end }}

--- a/charts/stirling-pdf/values.yaml
+++ b/charts/stirling-pdf/values.yaml
@@ -263,3 +263,44 @@ ingress:
   # -- For Kubernetes >= 1.18 you should specify the ingress-controller via the field ingressClassName
   # -- See https://kubernetes.io/blog/2020/04/02/improvements-to-the-ingress-api-in-kubernetes-1.18/#specifying-the-class-of-an-ingress
   ingressClassName:
+
+# -- HTTPRoute (Gateway API) for load balancing.
+# When enabled, an HTTPRoute resource is rendered alongside (or instead of) the Ingress.
+httpRoute:
+  enabled: false
+  # -- Stirling-pdf HTTPRoute labels
+  labels:
+    {}
+    # dns: route53
+
+  # -- Stirling-pdf HTTPRoute annotations
+  annotations:
+    {}
+
+  # -- HTTPRoute parentRefs (the Gateway(s) this route attaches to).
+  # Must be provided if HTTPRoute is enabled.
+  # See https://gateway-api.sigs.k8s.io/api-types/httproute/#attaching-to-gateways
+  parentRefs:
+    []
+    # - name: my-gateway
+    #   namespace: gateway-system
+    #   sectionName: http
+
+  # -- HTTPRoute hostnames. Must match the host the client requests.
+  hostnames:
+    []
+    # - stirling-pdf.example.com
+
+  # -- HTTPRoute rules. If empty, a default rule is rendered that
+  # routes all traffic to the chart's own Service on service.externalPort.
+  rules:
+    []
+    # - matches:
+    #     - path:
+    #         type: PathPrefix
+    #         value: /
+    #   timeouts:
+    #     request: 300s
+    #   backendRefs:
+    #     - name: stirling-pdf
+    #       port: 8080


### PR DESCRIPTION
## Summary

Adds optional HTTPRoute (Gateway API v1) support to the chart. Off by default, enabling it renders an `HTTPRoute` resource alongside the existing `Ingress`, allowing the chart to be deployed on clusters running a Gateway API controller. The pattern follows other charts that already ship native HTTPRoute support like ArgoCD.

## Motivation

K8s Gateway API is the successor of Ingress API.